### PR TITLE
Fix value requests from nodes for sensors with multiple subtypes

### DIFF
--- a/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/handler/MySensorsHandler.java
+++ b/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/handler/MySensorsHandler.java
@@ -9,6 +9,9 @@ package org.openhab.binding.mysensors.handler;
 
 import static org.openhab.binding.mysensors.MySensorsBindingConstants.*;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.OpenClosedType;
@@ -44,7 +47,7 @@ public class MySensorsHandler extends BaseThingHandler implements MySensorsUpdat
     private int childId = 0;
     private boolean requestAck = false;
 
-    private String oldMsgContent = "";
+    private Map<Integer, String> oldMsgContent = new HashMap<>();
 
     public MySensorsHandler(Thing thing) {
         super(thing);
@@ -63,10 +66,15 @@ public class MySensorsHandler extends BaseThingHandler implements MySensorsUpdat
     }
 
     @Override
-    public void dispose() {
+    public void handleRemoval() {
         getBridgeHandler().getBridgeConnection().removeUpdateListener(this);
+        super.handleRemoval();
+    }
+
+    @Override
+    public void bridgeHandlerDisposed(ThingHandler thingHandler, Bridge bridge) {
         updateStatus(ThingStatus.OFFLINE);
-        super.dispose();
+        super.bridgeHandlerDisposed(thingHandler, bridge);
     }
 
     /*
@@ -78,7 +86,8 @@ public class MySensorsHandler extends BaseThingHandler implements MySensorsUpdat
      */
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
-        String msg = "";
+        logger.debug("handleCommand called");
+        String msgPayload = "";
         int subType = 0;
         int int_requestack = 0;
         if (requestAck) {
@@ -91,29 +100,29 @@ public class MySensorsHandler extends BaseThingHandler implements MySensorsUpdat
 
             if (command instanceof OnOffType) {
                 if ((OnOffType) command == OnOffType.ON) {
-                    msg = "1";
+                    msgPayload = "1";
                 } else if ((OnOffType) command == OnOffType.OFF) {
-                    msg = "0";
+                    msgPayload = "0";
                 }
             }
 
         } else if (channelUID.getId().equals(CHANNEL_DIMMER)) {
             if (command instanceof PercentType) {
-                msg = ((PercentType) command).toString();
+                msgPayload = ((PercentType) command).toString();
                 subType = MYSENSORS_SUBTYPE_V_PERCENTAGE;
             } else {
                 if (command instanceof OnOffType) {
                     if ((OnOffType) command == OnOffType.ON) {
-                        msg = "1";
+                        msgPayload = "1";
                     } else if ((OnOffType) command == OnOffType.OFF) {
-                        msg = "0";
+                        msgPayload = "0";
                     }
                 }
                 subType = MYSENSORS_SUBTYPE_V_STATUS;
             }
         } else if (channelUID.getId().equals(CHANNEL_COVER)) {
             if (command instanceof PercentType) {
-                msg = ((PercentType) command).toString();
+                msgPayload = ((PercentType) command).toString();
                 subType = MYSENSORS_SUBTYPE_V_PERCENTAGE;
             } else {
                 if (command instanceof UpDownType) {
@@ -128,47 +137,52 @@ public class MySensorsHandler extends BaseThingHandler implements MySensorsUpdat
                     }
                 }
 
-                msg = "1";
+                msgPayload = "1";
 
             }
         } else if (channelUID.getId().equals(CHANNEL_HVAC_SETPOINT_HEAT)) {
             subType = MYSENSORS_SUBTYPE_V_HVAC_SETPOINT_HEAT;
-            msg = command.toString();
+            msgPayload = command.toString();
         } else if (channelUID.getId().equals(CHANNEL_HVAC_SETPOINT_COOL)) {// Unverified
             subType = MYSENSORS_SUBTYPE_V_HVAC_SETPOINT_COOL;
-            msg = command.toString();
+            msgPayload = command.toString();
         } else if (channelUID.getId().equals(CHANNEL_HVAC_FLOW_STATE)) {// Unverified
             subType = MYSENSORS_SUBTYPE_V_HVAC_FLOW_STATE;
-            msg = command.toString();
+            msgPayload = command.toString();
         } else if (channelUID.getId().equals(CHANNEL_HVAC_FLOW_MODE)) {
             subType = MYSENSORS_SUBTYPE_V_HVAC_FLOW_MODE;
-            msg = command.toString();
+            msgPayload = command.toString();
         } else if (channelUID.getId().equals(CHANNEL_HVAC_SPEED)) {// Unverified
             subType = MYSENSORS_SUBTYPE_V_HVAC_SPEED;
-            msg = command.toString();
+            msgPayload = command.toString();
         } else if (channelUID.getId().equals(CHANNEL_VAR1)) {// Unverified
             subType = MYSENSORS_SUBTYPE_V_VAR1;
-            msg = command.toString();
+            msgPayload = command.toString();
         } else if (channelUID.getId().equals(CHANNEL_VAR2)) {// Unverified
             subType = MYSENSORS_SUBTYPE_V_VAR2;
-            msg = command.toString();
+            msgPayload = command.toString();
         } else if (channelUID.getId().equals(CHANNEL_VAR3)) {
             subType = MYSENSORS_SUBTYPE_V_VAR3;
-            msg = command.toString();
+            msgPayload = command.toString();
         } else if (channelUID.getId().equals(CHANNEL_VAR4)) {
             subType = MYSENSORS_SUBTYPE_V_VAR4;
-            msg = command.toString();
+            msgPayload = command.toString();
         } else if (channelUID.getId().equals(CHANNEL_VAR5)) {
             subType = MYSENSORS_SUBTYPE_V_VAR5;
-            msg = command.toString();
+            msgPayload = command.toString();
         } else {
-            msg = "";
+            msgPayload = "";
         }
 
         MySensorsMessage newMsg = new MySensorsMessage(nodeId, childId, MYSENSORS_MSG_TYPE_SET, int_requestack, subType,
-                msg);
-        newMsg.setOldMsg(oldMsgContent);
-        oldMsgContent = msg;
+                msgPayload);
+
+        String oldPayload = oldMsgContent.get(subType);
+        if (oldPayload == null) {
+            oldPayload = "";
+        }
+        newMsg.setOldMsg(oldPayload);
+        oldMsgContent.put(subType, msgPayload);
 
         getBridgeHandler().getBridgeConnection().addMySensorsOutboundMessage(newMsg);
     }
@@ -241,18 +255,18 @@ public class MySensorsHandler extends BaseThingHandler implements MySensorsUpdat
                         } else {
                             updateState(channel, new DecimalType(msg.getMsg()));
                         }
-                        oldMsgContent = msg.getMsg();
+                        oldMsgContent.put(msg.getSubType(), msg.getMsg());
                     }
                 }
             } else if (msg.getMsgType() == MYSENSORS_MSG_TYPE_REQ) {
                 if (childId == msg.getChildId()) {
-                    logger.debug("Reqeust received!");
+                    logger.debug("Request received!");
                     msg.setMsgType(MYSENSORS_MSG_TYPE_SET);
-                    if (oldMsgContent.equals("")) {
-                        msg.setMsg("0");
-                    } else {
-                        msg.setMsg(oldMsgContent);
+                    String oldVal = oldMsgContent.get(msg.getSubType());
+                    if (oldVal == null) {
+                        oldVal = "";
                     }
+                    msg.setMsg(oldVal);
                     getBridgeHandler().getBridgeConnection().addMySensorsOutboundMessage(msg);
                 }
             }
@@ -277,12 +291,15 @@ public class MySensorsHandler extends BaseThingHandler implements MySensorsUpdat
     @Override
     public void bridgeHandlerInitialized(ThingHandler thingHandler, Bridge bridge) {
         MySensorsBridgeHandler bridgeHandler = (MySensorsBridgeHandler) thingHandler;
-        bridgeHandler.getBridgeConnection().addUpdateListener(this);
+        if (bridgeHandler.getBridgeConnection() == null) {
+            logger.error("Bridge connection not estblished yet - can't subscribe for updates");
+        } else {
+            bridgeHandler.getBridgeConnection().addUpdateListener(this);
+        }
     }
 
     @Override
     public void disconnectEvent() {
-        // TODO Auto-generated method stub
 
     }
 }


### PR DESCRIPTION
Previously, the value for the last modified subtype, not for the one that was requested, was returned.

Additionally, deregistration of the handler was moved from the `dispose` method to `handleRemoval` to prevent NPEs on shutdown.