### PR TITLE
S_COVER fix

### DIFF
--- a/addons/binding/org.openhab.binding.mysensors/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.mysensors/ESH-INF/thing/thing-types.xml
@@ -2173,7 +2173,6 @@
 		<item-type>Switch</item-type>
 		<label>Armed Status</label>
 		<description>Armed Status</description>
-		<state readOnly="true"></state>
 	</channel-type>
 	<channel-type id="dimmer-channel">
 		<item-type>Dimmer</item-type>

--- a/addons/binding/org.openhab.binding.mysensors/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.mysensors/ESH-INF/thing/thing-types.xml
@@ -719,6 +719,7 @@
 
 		<channels>
 			<channel id="dimmer" typeId="dimmer-channel" />
+			<channel id="status" typeId="status-channel" />
 			<channel id="watt" typeId="watt-channel" />
 			<channel id="battery" typeId="battery-channel" />
 			<channel id="lastupdate" typeId="lastupdate-channel" />

--- a/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/converter/MySensorsUpDownTypeConverter.java
+++ b/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/converter/MySensorsUpDownTypeConverter.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.mysensors.converter;
 
+import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.library.types.StopMoveType;
 import org.eclipse.smarthome.core.library.types.UpDownType;
 import org.eclipse.smarthome.core.types.Command;
@@ -21,16 +22,22 @@ public class MySensorsUpDownTypeConverter implements MySensorsTypeConverter {
     @Override
     public Integer typeFromChannelCommand(String channel, Command command) {
         if (channel.equals(MySensorsBindingConstants.CHANNEL_COVER)) {
-            if (command.equals(UpDownType.UP)) {
-                return MySensorsMessage.MYSENSORS_SUBTYPE_V_UP;
-            } else if (command.equals(UpDownType.DOWN)) {
-                return MySensorsMessage.MYSENSORS_SUBTYPE_V_DOWN;
+            if (command instanceof UpDownType) {
+                if (command.equals(UpDownType.UP)) {
+                    return MySensorsMessage.MYSENSORS_SUBTYPE_V_UP;
+                } else if (command.equals(UpDownType.DOWN)) {
+                    return MySensorsMessage.MYSENSORS_SUBTYPE_V_DOWN;
+                } else {
+                    throw new IllegalArgumentException("Invalid command of type UpDownType: " + command);
+                }
             } else if (command instanceof StopMoveType) {
                 if (command.equals(StopMoveType.STOP)) {
                     return MySensorsMessage.MYSENSORS_SUBTYPE_V_STOP;
                 } else {
                     throw new IllegalArgumentException("Invalid command of type StopMoveType");
                 }
+            } else if (command instanceof PercentType) {
+                return MySensorsMessage.MYSENSORS_SUBTYPE_V_PERCENTAGE;
             } else {
                 throw new IllegalArgumentException("Invalid command (" + command + ") passed to UpDown adapter");
 
@@ -46,8 +53,10 @@ public class MySensorsUpDownTypeConverter implements MySensorsTypeConverter {
             return UpDownType.DOWN;
         } else if (value.getType() == MySensorsMessage.MYSENSORS_SUBTYPE_V_UP) {
             return UpDownType.UP;
+        } else if (value.getType() == MySensorsMessage.MYSENSORS_SUBTYPE_V_PERCENTAGE) {
+            return new PercentType(value.getValue());
         } else {
-            throw new IllegalArgumentException("Variable " + value.getType() + " is not up/down");
+            throw new IllegalArgumentException("Variable " + value.getType() + " is not up/down or percent type");
         }
     }
 
@@ -61,9 +70,12 @@ public class MySensorsUpDownTypeConverter implements MySensorsTypeConverter {
             }
         } else if (state instanceof StopMoveType) {
             return "1";
+        } else if (state instanceof PercentType) {
+            return state.toFullString();
         } else {
-            throw new IllegalStateException("UpDown command is the only one command allowed by this adapter, passed: "
-                    + state + "(" + (state != null ? state.getClass() : "") + ")");
+            throw new IllegalStateException(
+                    "UpDown/Percent command are the only one command allowed by this adapter, passed: " + state + "("
+                            + (state != null ? state.getClass() : "") + ")");
         }
     }
 

--- a/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/handler/MySensorsBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/handler/MySensorsBridgeHandler.java
@@ -96,6 +96,7 @@ public class MySensorsBridgeHandler extends BaseBridgeHandler implements MySenso
         unregisterDeviceDiscoveryService();
 
         if (myGateway != null) {
+            myGateway.removeEventListener(this);
             myGateway.shutdown();
         }
 

--- a/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/handler/MySensorsThingHandler.java
+++ b/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/handler/MySensorsThingHandler.java
@@ -279,11 +279,11 @@ public class MySensorsThingHandler extends BaseThingHandler implements MySensors
     }
 
     private String getChannelNameFromVar(MySensorsVariable var) {
-        // Cover has a specific behaviour
-        if (!getThing().getThingTypeUID().equals(MySensorsBindingConstants.THING_TYPE_COVER)) {
-            return CHANNEL_MAP.get(var.getType());
-        } else {
+        // Cover thing has a specific behavior
+        if (getThing().getThingTypeUID().equals(MySensorsBindingConstants.THING_TYPE_COVER)) {
             return MySensorsBindingConstants.CHANNEL_COVER;
+        } else {
+            return CHANNEL_MAP.get(var.getType());
         }
     }
 

--- a/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/handler/MySensorsThingHandler.java
+++ b/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/handler/MySensorsThingHandler.java
@@ -26,6 +26,7 @@ import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
+import org.openhab.binding.mysensors.MySensorsBindingConstants;
 import org.openhab.binding.mysensors.config.MySensorsSensorConfiguration;
 import org.openhab.binding.mysensors.converter.MySensorsTypeConverter;
 import org.openhab.binding.mysensors.internal.event.MySensorsGatewayEventListener;
@@ -91,12 +92,23 @@ public class MySensorsThingHandler extends BaseThingHandler implements MySensors
     }
 
     @Override
+    public void dispose() {
+        myGateway.removeEventListener(this);
+        super.dispose();
+    }
+
+    @Override
     public void bridgeStatusChanged(ThingStatusInfo bridgeStatusInfo) {
         logger.debug("MySensors Bridge Status updated to {} for device: {}", bridgeStatusInfo.getStatus().toString(),
                 getThing().getUID().toString());
         if (bridgeStatusInfo.getStatus().equals(ThingStatus.ONLINE)
                 || bridgeStatusInfo.getStatus().equals(ThingStatus.OFFLINE)) {
-            registerListeners();
+
+            if (bridgeStatusInfo.getStatus().equals(ThingStatus.ONLINE)) {
+                registerListeners();
+            } else {
+                myGateway.removeEventListener(this);
+            }
 
             // the node has the same status of the bridge
             updateStatus(bridgeStatusInfo.getStatus());
@@ -259,11 +271,20 @@ public class MySensorsThingHandler extends BaseThingHandler implements MySensors
     }
 
     private void handleChildUpdateEvent(MySensorsVariable var) {
-        String channelName = CHANNEL_MAP.get(var.getType());
+        String channelName = getChannelNameFromVar(var);
         State newState = loadAdapterForChannelType(channelName).stateFromChannel(var);
         logger.debug("Updating channel: {}({}) value to: {}", channelName, var.getType(), newState);
         updateState(channelName, newState);
 
+    }
+
+    private String getChannelNameFromVar(MySensorsVariable var) {
+        // Cover has a specific behaviour
+        if (!getThing().getThingTypeUID().equals(MySensorsBindingConstants.THING_TYPE_COVER)) {
+            return CHANNEL_MAP.get(var.getType());
+        } else {
+            return MySensorsBindingConstants.CHANNEL_COVER;
+        }
     }
 
     private MySensorsTypeConverter loadAdapterForChannelType(String channelName) {

--- a/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/internal/gateway/MySensorsGateway.java
+++ b/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/internal/gateway/MySensorsGateway.java
@@ -458,7 +458,7 @@ public class MySensorsGateway implements MySensorsGatewayEventListener {
                         break;
                     case MySensorsMessage.MYSENSORS_MSG_TYPE_REQ:
                     case MySensorsMessage.MYSENSORS_MSG_TYPE_SET:
-                        ret = handleSetReqMessage(msg);
+                        ret = handleSetReqMessage(msg, true);
                         break;
                     case MySensorsMessage.MYSENSORS_MSG_TYPE_PRESENTATION:
                         ret = handlePresentationMessage(msg);
@@ -483,7 +483,7 @@ public class MySensorsGateway implements MySensorsGatewayEventListener {
             if (msg.getDirection() == MySensorsMessage.MYSENSORS_MSG_DIRECTION_OUTGOING) {
                 switch (msg.getMsgType()) {
                     case MySensorsMessage.MYSENSORS_MSG_TYPE_SET:
-                        ret = handleSetReqMessage(msg);
+                        ret = handleSetReqMessage(msg, false);
                         break;
                 }
             } else {
@@ -551,7 +551,7 @@ public class MySensorsGateway implements MySensorsGatewayEventListener {
         return ret;
     }
 
-    private boolean handleSetReqMessage(MySensorsMessage msg) {
+    private boolean handleSetReqMessage(MySensorsMessage msg, boolean dispatchUpdate) {
         boolean ret = false;
 
         MySensorsNode node = getNode(msg.getNodeId());
@@ -573,8 +573,10 @@ public class MySensorsGateway implements MySensorsGatewayEventListener {
                             logger.trace("Variable {}({}) found in child, post-update value: {}",
                                     variable.getClass().getSimpleName(), variable.getType(), variable.getValue());
 
-                            myEventRegister.notifyNodeUpdateEvent(node, child, variable,
-                                    MySensorsNodeUpdateEventType.UPDATE);
+                            if (dispatchUpdate) {
+                                myEventRegister.notifyNodeUpdateEvent(node, child, variable,
+                                        MySensorsNodeUpdateEventType.UPDATE);
+                            }
                         } else {
                             logger.warn("Could not set value to node {} if not reachable", node.getNodeId());
                         }

--- a/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/internal/protocol/MySensorsAbstractConnection.java
+++ b/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/internal/protocol/MySensorsAbstractConnection.java
@@ -340,24 +340,28 @@ public abstract class MySensorsAbstractConnection implements Runnable {
                     logger.debug(line);
                     MySensorsMessage msg = MySensorsMessage.parse(line);
 
-                    msg.setDirection(MySensorsMessage.MYSENSORS_MSG_DIRECTION_INCOMING);
+                    // Debug message are useless, just print it
+                    if (!msg.isDebugMessage()) {
+                        msg.setDirection(MySensorsMessage.MYSENSORS_MSG_DIRECTION_INCOMING);
 
-                    // Have we get a I_HEARBEAT_RESPONSE
-                    if (msg.isHeartbeatResponseMessage()) {
-                        handleSmartSleepMessage(msg);
+                        // Have we get a I_HEARBEAT_RESPONSE
+                        if (msg.isHeartbeatResponseMessage()) {
+                            handleSmartSleepMessage(msg);
+                        }
+
+                        // Have we get a I_VERSION message?
+                        if (msg.isIVersionMessage()) {
+                            iVersionMessageReceived(msg.getMsg());
+                        }
+
+                        // Is this an ACK message?
+                        if (msg.getAck() == 1) {
+                            handleAckReceived(msg);
+                        }
+
+                        myEventRegister.notifyMessageReceived(msg);
                     }
 
-                    // Have we get a I_VERSION message?
-                    if (msg.isIVersionMessage()) {
-                        iVersionMessageReceived(msg.getMsg());
-                    }
-
-                    // Is this an ACK message?
-                    if (msg.getAck() == 1) {
-                        handleAckReceived(msg);
-                    }
-
-                    myEventRegister.notifyMessageReceived(msg);
                 } catch (InterruptedException e) {
                     logger.warn("Interrupted MySensorsReader");
                 } catch (Exception e) {
@@ -617,7 +621,7 @@ public abstract class MySensorsAbstractConnection implements Runnable {
                             && ackM.getMsgType() == msg.getMsgType() && ackM.getSubType() == msg.getSubType()
                             && ackM.getAck() == msg.getAck() && ackM.getMsg().equals(msg.getMsg())) {
                         iterator.remove();
-                        ret = true && (msg.getRetries() != 0); // First time we only clear old ack, if present
+                        ret = (msg.getRetries() != 0); // First time we only clear old ack, if present
                     }
                 }
             }

--- a/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/internal/protocol/message/MySensorsMessage.java
+++ b/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/internal/protocol/message/MySensorsMessage.java
@@ -489,6 +489,17 @@ public class MySensorsMessage {
     }
 
     /**
+     * Is this a debug message?
+     *
+     * @return true if this message is I_DEBUG
+     */
+    public boolean isDebugMessage() {
+        return (nodeId == MySensorsNode.MYSENSORS_NODE_ID_RESERVED_0)
+                && (childId == MySensorsChild.MYSENSORS_CHILD_ID_RESERVED_255)
+                && (msgType == MYSENSORS_MSG_TYPE_INTERNAL) && (subType == MYSENSORS_SUBTYPE_I_DEBUG);
+    }
+
+    /**
      * Generate a custom hash by message parts passed as vararg
      * Usage example: customHashCode(MYSENSORS_MSG_PAYLOAD_PART, MYSENSORS_MSG_SUBTYPE_PART);
      *


### PR DESCRIPTION
Here is a FIX for [S_COVER issue](https://github.com/tobof/openhab2-addons/issues/65) (include also minor changes). Summary of what is changed since last PR:

1. [FIX] armed channel is not read-only [cf1c505](https://github.com/andreacioni/openhab2-addons/commit/cf1c505e9fa976d097c8c64b7e1cf624ecca7666)	

1. I_DEBUG message not forwarded [7ae5f64](https://github.com/andreacioni/openhab2-addons/commit/7ae5f64f9bd4c5f748e6eb694760fbf642f6aa5a)

1. [FIX] COVER thing [66e2afb](https://github.com/andreacioni/openhab2-addons/commit/66e2afbd051f1b2c4c55c31b4de1565c38d6cacb)
-Percent type command handling
-Gateway now sends update to child only for incoming message
-getChannelNameFromVar in MySensorsThingHandler

1. Added status channel to dimmer thing [772d8e4](https://github.com/tobof/openhab2-addons/pull/66/commits/772d8e4744de48706b2f273a36827c6639095e14)