### PR TITLE
added new setting for pure white colors

### DIFF
--- a/addons/binding/org.openhab.binding.mysensors.test/test/mqttPulseSensor.sh
+++ b/addons/binding/org.openhab.binding.mysensors.test/test/mqttPulseSensor.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+#### Represent Engergy meter 
+mosquitto_pub -t "mygateway1-out/5/0/0/0/13" -m ""
+
+# set V_VAR1 status 
+#mosquitto_pub -t "mygateway1-out/5/0/1/0/24" -m "1399"
+
+# request V_VAR1 status
+mosquitto_pub -t "mygateway1-out/5/0/2/0/24" -m ""

--- a/addons/binding/org.openhab.binding.mysensors/ESH-INF/thing/SMyMessage.xml
+++ b/addons/binding/org.openhab.binding.mysensors/ESH-INF/thing/SMyMessage.xml
@@ -3,7 +3,7 @@
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
-	<thing-type id="mysensorsMessage">
+	<thing-type id="mySensorsMessage">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge-ser" />
 			<bridge-type-ref id="bridge-eth" />

--- a/addons/binding/org.openhab.binding.mysensors/ESH-INF/thing/SRgbwLight.xml
+++ b/addons/binding/org.openhab.binding.mysensors/ESH-INF/thing/SRgbwLight.xml
@@ -70,6 +70,12 @@
 				<description>Does this node support Smartsleep? A message to the node is only send in response to a heartbeat!</description>
 				<default>false</default>
 			</parameter>
+			<parameter name="usePureWhiteLightInRGBW" type="boolean" required="false">
+				<label>Pure White</label>
+				<description>If this is enabled and a white color for this item is selected only the white channel will be activated.
+				Otherwise the white channel is set to the lowest of the RGB values and all 4 are send to the item.</description>
+				<default>false</default>
+			</parameter>
 		</config-description>
 	</thing-type>
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.mysensors/ESH-INF/thing/channel-types.xml
+++ b/addons/binding/org.openhab.binding.mysensors/ESH-INF/thing/channel-types.xml
@@ -278,7 +278,7 @@
 		<description>MySensors Water Electric Condictivity Channel</description>
 		<state readOnly="false"></state>
 	</channel-type>
-	<channel-type id="mysensorsMessage-channel">
+	<channel-type id="mySensorsMessage-channel">
 		<item-type>String</item-type>
 		<label>MySensors Message</label>
 		<description>MySensors Message Channel</description>

--- a/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/config/MySensorsBridgeConfiguration.java
+++ b/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/config/MySensorsBridgeConfiguration.java
@@ -31,7 +31,6 @@ public class MySensorsBridgeConfiguration {
     public Integer networkSanCheckConnectionFailAttempts; // connection will wait this number of attempts before disconnecting
     public boolean networkSanCheckSendHeartbeat; // network sanity checker will also send heartbeats to all known nodes
     public Integer networkSanCheckSendHeartbeatFailAttempts; // disconnect nodes that fail to answer to heartbeat request
-    public boolean usePureWhiteLightInRGBW; // if a pure white rgbw value is selected in openhab the binding will only switch on the white led not the rgb part
 
     @Override
     public String toString() {
@@ -51,7 +50,6 @@ public class MySensorsBridgeConfiguration {
                 + ", networkSanCheckConnectionFailAttempts=" + networkSanCheckConnectionFailAttempts 
                 + ", networkSanCheckSendHeartbeat=" + networkSanCheckSendHeartbeat
                 + ", networkSanCheckSendHeartbeatFailAttempts=" + networkSanCheckSendHeartbeatFailAttempts
-                + ", usePureWhiteLightInRGBW=" + usePureWhiteLightInRGBW
                 + "]";
     }
 

--- a/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/config/MySensorsBridgeConfiguration.java
+++ b/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/config/MySensorsBridgeConfiguration.java
@@ -31,6 +31,7 @@ public class MySensorsBridgeConfiguration {
     public Integer networkSanCheckConnectionFailAttempts; // connection will wait this number of attempts before disconnecting
     public boolean networkSanCheckSendHeartbeat; // network sanity checker will also send heartbeats to all known nodes
     public Integer networkSanCheckSendHeartbeatFailAttempts; // disconnect nodes that fail to answer to heartbeat request
+    public boolean usePureWhiteLightInRGBW; // if a pure white rgbw value is selected in openhab the binding will only switch on the white led not the rgb part
 
     @Override
     public String toString() {
@@ -49,7 +50,8 @@ public class MySensorsBridgeConfiguration {
                 + ", networkSanCheckInterval=" + networkSanCheckInterval 
                 + ", networkSanCheckConnectionFailAttempts=" + networkSanCheckConnectionFailAttempts 
                 + ", networkSanCheckSendHeartbeat=" + networkSanCheckSendHeartbeat
-                + ", networkSanCheckSendHeartbeatFailAttempts=" + networkSanCheckSendHeartbeatFailAttempts 
+                + ", networkSanCheckSendHeartbeatFailAttempts=" + networkSanCheckSendHeartbeatFailAttempts
+                + ", usePureWhiteLightInRGBW=" + usePureWhiteLightInRGBW
                 + "]";
     }
 

--- a/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/config/MySensorsSensorConfiguration.java
+++ b/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/config/MySensorsSensorConfiguration.java
@@ -57,16 +57,23 @@ public class MySensorsSensorConfiguration {
      */
     public boolean requestHeartbeatResponse;
 
+    /**
+     * If a pure white rgbw value is selected in openhab the binding will only switch on the white led not the rgb part
+     */
+    public boolean usePureWhiteLightInRGBW;
+
     @Override
     public String toString() {
-        return "MySensorsSensorConfiguration [nodeId=" + nodeId
-                + ", childId=" + childId
-                + ", requestAck=" + requestAck
-                + ", revertState=" + revertState
-                + ", smartSleep=" + smartSleep
-                + ", childUpdateTimeout=" + childUpdateTimeout
-                + ", nodeUpdateTimeout=" + nodeUpdateTimeout
-                + ", requestHeartbeatResponse=" + requestHeartbeatResponse
-                + "]";
+        return "MySensorsSensorConfiguration{" +
+                "nodeId=" + nodeId +
+                ", childId=" + childId +
+                ", requestAck=" + requestAck +
+                ", revertState=" + revertState +
+                ", smartSleep=" + smartSleep +
+                ", childUpdateTimeout=" + childUpdateTimeout +
+                ", nodeUpdateTimeout=" + nodeUpdateTimeout +
+                ", requestHeartbeatResponse=" + requestHeartbeatResponse +
+                ", usePureWhiteLightInRGBW=" + usePureWhiteLightInRGBW +
+                '}';
     }
 }

--- a/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/converter/MySensorsRGBWPureTypeConverter.java
+++ b/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/converter/MySensorsRGBWPureTypeConverter.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.mysensors.converter;
+
+import org.eclipse.smarthome.core.library.types.HSBType;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.State;
+
+import java.awt.*;
+
+/**
+ * Used to convert a String from an incoming MySensors message to a HSBType
+ * If the color value exceeds a certain limit a pure white color is generated
+ * 
+ * @author Oliver Hilsky
+ *
+ */
+public class MySensorsRGBWPureTypeConverter implements MySensorsTypeConverter {
+
+    private static final int WHITE_LIMIT = 245;
+    private final MySensorsRGBWTypeConverter standardRGBWConverter = new MySensorsRGBWTypeConverter();
+
+    @Override
+    public State fromString(String s) {
+        return standardRGBWConverter.fromString(s);
+    }
+    
+    @Override
+    public String fromCommand(Command value) {
+        if(value instanceof HSBType) {
+            HSBType hsbValue = (HSBType) value;
+            
+            Color color = Color.getHSBColor(hsbValue.getHue().floatValue() / 360, hsbValue.getSaturation().floatValue() / 100, hsbValue.getBrightness().floatValue() / 100);
+            
+            int redValue = color.getRed();
+            int greenValue = color.getGreen();
+            int blueValue = color.getBlue();
+            int whiteValue = Math.min(redValue, Math.min(greenValue, blueValue));
+
+            // if all color values are over the WHITE_LIMIT it is assumed that this should be pure white and only the white channel is used
+            if (redValue > WHITE_LIMIT && greenValue > WHITE_LIMIT && blueValue > WHITE_LIMIT) {
+                String rgbDisabled = "000000";
+                String w = Integer.toHexString(whiteValue);
+                return rgbDisabled.concat(w);
+            } else {
+                return standardRGBWConverter.fromCommand(value);
+            }
+        }
+
+        return "";
+    }
+}

--- a/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/handler/MySensorsThingHandler.java
+++ b/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/handler/MySensorsThingHandler.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import org.eclipse.smarthome.core.library.types.DateTimeType;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.HSBType;
+import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.ChannelUID;
@@ -147,7 +148,11 @@ public class MySensorsThingHandler extends BaseThingHandler implements MySensors
             // if the brightness (Percentage) is changed it must be send via V_PERCENTAGE 
             // and another converter must be used
             boolean rgbPercentageValue = false;
-            if((channelUID.getId().equals(CHANNEL_RGB) || channelUID.getId().equals(CHANNEL_RGBW)) && !(command instanceof HSBType)) {
+            boolean rgbOnOffValue = false;
+            if ((channelUID.getId().equals(CHANNEL_RGB) || channelUID.getId().equals(CHANNEL_RGBW)) && (command instanceof OnOffType)) {
+                adapter = loadAdapterForChannelType(CHANNEL_STATUS);
+                rgbOnOffValue = true;
+            } else if((channelUID.getId().equals(CHANNEL_RGB) || channelUID.getId().equals(CHANNEL_RGBW)) && !(command instanceof HSBType)) {
                 adapter = loadAdapterForChannelType(CHANNEL_PERCENTAGE);
                 rgbPercentageValue = true;
 
@@ -158,6 +163,8 @@ public class MySensorsThingHandler extends BaseThingHandler implements MySensors
             } else {
                 adapter = loadAdapterForChannelType(channelUID.getId());
             }
+            
+            logger.debug("Adapter: {} loaded", adapter.getClass());
 
             if (adapter != null) {
                 logger.trace("Adapter {} found for type {}", adapter.getClass().getSimpleName(), channelUID.getId());
@@ -174,6 +181,8 @@ public class MySensorsThingHandler extends BaseThingHandler implements MySensors
                         MySensorsMessageSubType subType;
                         if(rgbPercentageValue) {
                             subType = MySensorsMessageSubType.V_PERCENTAGE;
+                        } else if(rgbOnOffValue) {
+                            subType = MySensorsMessageSubType.V_STATUS;
                         } else {
                             subType = var.getType();
                         }

--- a/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/handler/MySensorsThingHandler.java
+++ b/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/handler/MySensorsThingHandler.java
@@ -8,7 +8,19 @@
  */
 package org.openhab.binding.mysensors.handler;
 
-import static org.openhab.binding.mysensors.MySensorsBindingConstants.*;
+import static org.openhab.binding.mysensors.MySensorsBindingConstants.CHANNEL_BATTERY;
+import static org.openhab.binding.mysensors.MySensorsBindingConstants.CHANNEL_COVER;
+import static org.openhab.binding.mysensors.MySensorsBindingConstants.CHANNEL_LAST_UPDATE;
+import static org.openhab.binding.mysensors.MySensorsBindingConstants.CHANNEL_MAP;
+import static org.openhab.binding.mysensors.MySensorsBindingConstants.CHANNEL_MYSENSORS_MESSAGE;
+import static org.openhab.binding.mysensors.MySensorsBindingConstants.CHANNEL_PERCENTAGE;
+import static org.openhab.binding.mysensors.MySensorsBindingConstants.CHANNEL_RGB;
+import static org.openhab.binding.mysensors.MySensorsBindingConstants.CHANNEL_RGBW;
+import static org.openhab.binding.mysensors.MySensorsBindingConstants.CHANNEL_STATUS;
+import static org.openhab.binding.mysensors.MySensorsBindingConstants.INVERSE_THING_UID_MAP;
+import static org.openhab.binding.mysensors.MySensorsBindingConstants.MYSENSORS_CHILD_ID_ALL_KNOWING;
+import static org.openhab.binding.mysensors.MySensorsBindingConstants.MYSENSORS_NODE_ID_ALL_KNOWING;
+import static org.openhab.binding.mysensors.MySensorsBindingConstants.TYPE_MAP;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;

--- a/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/handler/MySensorsThingHandler.java
+++ b/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/handler/MySensorsThingHandler.java
@@ -31,6 +31,7 @@ import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
 import org.openhab.binding.mysensors.MySensorsBindingConstants;
 import org.openhab.binding.mysensors.config.MySensorsSensorConfiguration;
+import org.openhab.binding.mysensors.converter.MySensorsRGBWPureTypeConverter;
 import org.openhab.binding.mysensors.converter.MySensorsTypeConverter;
 import org.openhab.binding.mysensors.internal.event.MySensorsGatewayEventListener;
 import org.openhab.binding.mysensors.internal.event.MySensorsNodeUpdateEventType;
@@ -45,7 +46,6 @@ import org.openhab.binding.mysensors.internal.sensors.MySensorsChildConfig;
 import org.openhab.binding.mysensors.internal.sensors.MySensorsNode;
 import org.openhab.binding.mysensors.internal.sensors.MySensorsNodeConfig;
 import org.openhab.binding.mysensors.internal.sensors.MySensorsVariable;
-import org.openhab.binding.mysensors.internal.sensors.variable.MySensorsVariableVPercentage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -151,6 +151,11 @@ public class MySensorsThingHandler extends BaseThingHandler implements MySensors
             if((channelUID.getId().equals(CHANNEL_RGB) || channelUID.getId().equals(CHANNEL_RGBW)) && !(command instanceof HSBType)) {
                 adapter = loadAdapterForChannelType(CHANNEL_PERCENTAGE);
                 rgbPercentageValue = true;
+
+            // RGBW only
+            // if the config is set to use pure white instead of mixed white use special converter
+            } else if(channelUID.getId().equals(CHANNEL_RGBW) && getBridgeHandler().getBridgeConfiguration().usePureWhiteLightInRGBW) {
+                adapter = new MySensorsRGBWPureTypeConverter();
             } else {
                 adapter = loadAdapterForChannelType(channelUID.getId());
             }

--- a/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/handler/MySensorsThingHandler.java
+++ b/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/handler/MySensorsThingHandler.java
@@ -17,7 +17,6 @@ import java.util.Map;
 import org.eclipse.smarthome.core.library.types.DateTimeType;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.HSBType;
-import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.ChannelUID;
@@ -154,7 +153,7 @@ public class MySensorsThingHandler extends BaseThingHandler implements MySensors
 
             // RGBW only
             // if the config is set to use pure white instead of mixed white use special converter
-            } else if(channelUID.getId().equals(CHANNEL_RGBW) && getBridgeHandler().getBridgeConfiguration().usePureWhiteLightInRGBW) {
+            } else if(channelUID.getId().equals(CHANNEL_RGBW) && configuration.usePureWhiteLightInRGBW) {
                 adapter = new MySensorsRGBWPureTypeConverter();
             } else {
                 adapter = loadAdapterForChannelType(channelUID.getId());

--- a/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/internal/gateway/MySensorsGateway.java
+++ b/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/internal/gateway/MySensorsGateway.java
@@ -563,14 +563,15 @@ public class MySensorsGateway implements MySensorsGatewayEventListener {
                         }
                     } else {
                         String value = variable.getValue();
-                        if (value != null) {
-                            logger.debug("Request received!");
-                            msg.setMsgType(MySensorsMessageType.SET);
-                            msg.setMsg(value);
-                            myCon.sendMessage(msg);
+                        logger.debug("Request received!");
+                        msg.setMsgType(MySensorsMessageType.SET);
+                        if(value != null) {
+                        msg.setMsg(value);
                         } else {
-                            logger.warn("Request received, but variable state is not yet defined");
+                            msg.setMsg("0");
                         }
+                        myCon.sendMessage(msg);
+                        
                     }
                     return true;
                 } else {

--- a/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/internal/gateway/MySensorsGateway.java
+++ b/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/internal/gateway/MySensorsGateway.java
@@ -571,7 +571,6 @@ public class MySensorsGateway implements MySensorsGatewayEventListener {
                             msg.setMsg("0");
                         }
                         myCon.sendMessage(msg);
-                        
                     }
                     return true;
                 } else {

--- a/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/internal/protocol/MySensorsAbstractConnection.java
+++ b/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/internal/protocol/MySensorsAbstractConnection.java
@@ -507,7 +507,6 @@ public abstract class MySensorsAbstractConnection implements Runnable {
                                 }
                                 String output = MySensorsMessage.generateAPIString(msg);
                                 logger.debug("Sending to MySensors: {}", output.trim());
-
                                 sendMessage(output);
                             } else {
                                 addMySensorsOutboundMessage(msg);

--- a/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/internal/sensors/MySensorsChild.java
+++ b/addons/binding/org.openhab.binding.mysensors/src/main/java/org/openhab/binding/mysensors/internal/sensors/MySensorsChild.java
@@ -182,9 +182,6 @@ public abstract class MySensorsChild implements Mergeable {
             throw new NoContentException("Cannot add a null variable");
         }
         synchronized (variableMap) {
-            if (variableMap.containsKey(var.getType())) {
-                logger.warn("Overwrite variable: {}", var.getType());
-            }
             variableMap.put(var.getType(), var);
         }
     }


### PR DESCRIPTION
[MySensors] added new setting `usePureWhiteLightInRGBW` to the gateway that makes the RGBW type converter convert a pure white color to a hex value without RGB part (eg. 255 255 255 255 is converted to "000000ff"). This should solve #91

To keep things separated I created a new `MySensorsRGBWPureTypeConverter` class that handles the different conversion but relies on the standard converter for everything but this special case